### PR TITLE
Fix a bug in safari 9.0.3

### DIFF
--- a/src/templates/template/components/saveJsZip.jsx
+++ b/src/templates/template/components/saveJsZip.jsx
@@ -68,7 +68,7 @@ const setMountPotion = () => {
     // 点的位置居中
     const list = ReactDOM.findDOMNode(this.refs.list);
     const listHeight = list.getBoundingClientRect().height;
-    list.style = \`margin-top: -\$\{listHeight / 2\}px\`;`);
+    list.style.marginTop = \` -\$\{listHeight / 2\}px\`;`);
 };
 
 const setScrollScreen = () => {

--- a/src/templates/template/index.jsx
+++ b/src/templates/template/index.jsx
@@ -45,7 +45,7 @@ export default class Templates extends React.Component {
     if (this.listPoint) {
       const list = ReactDOM.findDOMNode(this.listComp);
       const listHeight = list.getBoundingClientRect().height;
-      list.style = `margin-top: -${listHeight / 2}px`;
+      list.style.marginTop = `-${listHeight / 2}px`;
     }
     /* $(document).bind('mousemove', (e) => {
      console.log(e)


### PR DESCRIPTION
Hi. I am a big fan of your product, thanks in advance for your efforts.
I was trying to get the customized code in https://motion.ant.design/cases/splicing,
and chose the combination of [banner_0, content_2, footer_1, 侧边小点， 整屏滚动]
The generated code, when running in safari 9.0.3, had typeError: Attempted to assign to readonly property.

I have already fixed the css value update in the template code, and now it's working fine.
Feel free to check it out.

Thanks